### PR TITLE
refactor: DeepL 구현체와 인터페이스로 역할 분리

### DIFF
--- a/src/main/java/com/tangtang/polingo/translate/controller/TranslateController.java
+++ b/src/main/java/com/tangtang/polingo/translate/controller/TranslateController.java
@@ -10,7 +10,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -24,8 +29,9 @@ public class TranslateController {
 
     @PostMapping("/plain")
     @Operation(summary = "텍스트 번역 API", description = "텍스트를 번역합니다.")
-    public TranslateResponse translateText(@RequestBody PlainTextTranslateRequest request) {
-        return translateService.translatePlainText(request);
+    public ResponseEntity<TranslateResponse> translateText(@RequestBody PlainTextTranslateRequest request) {
+        TranslateResponse result = translateService.translatePlainText(request);
+        return ResponseEntity.ok(result);
     }
 
     @PostMapping("/image")

--- a/src/main/java/com/tangtang/polingo/translate/dto/PlainTextTranslateRequest.java
+++ b/src/main/java/com/tangtang/polingo/translate/dto/PlainTextTranslateRequest.java
@@ -4,7 +4,7 @@ package com.tangtang.polingo.translate.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tangtang.polingo.global.constant.Language;
 
-public record PlainTextTranslateRequest(Language sourceType, String text){
+public record PlainTextTranslateRequest(Language sourceType, String text) {
     @JsonIgnore
     public String getSource() {
         return sourceType.getCode();

--- a/src/main/java/com/tangtang/polingo/translate/dto/TranslateResponse.java
+++ b/src/main/java/com/tangtang/polingo/translate/dto/TranslateResponse.java
@@ -4,5 +4,5 @@ package com.tangtang.polingo.translate.dto;
 import lombok.Builder;
 
 @Builder
-public record TranslateResponse(String originalText, String translatedText){
+public record TranslateResponse(String originalText, String translatedText) {
 }

--- a/src/main/java/com/tangtang/polingo/translate/service/DeepLTranslationImpl.java
+++ b/src/main/java/com/tangtang/polingo/translate/service/DeepLTranslationImpl.java
@@ -1,0 +1,26 @@
+package com.tangtang.polingo.translate.service;
+
+import com.deepl.api.DeepLException;
+import com.deepl.api.TextResult;
+import com.deepl.api.Translator;
+import com.tangtang.polingo.global.constant.Language;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeepLTranslationImpl implements Translation {
+    private static final String TARGET = Language.KOREA.getCode();
+    private final Translator translator;
+
+    @Override
+    public String translate(String text, String type) {
+        TextResult result;
+        try {
+            result = translator.translateText(text, type, TARGET);
+        } catch (DeepLException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return result.getText();
+    }
+}

--- a/src/main/java/com/tangtang/polingo/translate/service/TranslateService.java
+++ b/src/main/java/com/tangtang/polingo/translate/service/TranslateService.java
@@ -1,32 +1,22 @@
 package com.tangtang.polingo.translate.service;
 
-import com.deepl.api.DeepLException;
-import com.deepl.api.TextResult;
-import com.deepl.api.Translator;
-import com.tangtang.polingo.global.constant.Language;
 import com.tangtang.polingo.translate.dto.PlainTextTranslateRequest;
 import com.tangtang.polingo.translate.dto.TranslateResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TranslateService {
-    private static final String TARGET = Language.KOREA.getCode();
-    private final Translator translator;
+    private final Translation translation;
 
-    public TranslateResponse translatePlainText(PlainTextTranslateRequest request){
-        TextResult result;
-        try {
-            result = translator.translateText(request.text(), request.getSource(), TARGET);
-        } catch (DeepLException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+    public TranslateResponse translatePlainText(PlainTextTranslateRequest request) {
+        String original = request.text();
+        String result = translation.translate(original, request.getSource());
+
         return TranslateResponse.builder()
-                .originalText(request.text())
-                .translatedText(result.getText())
-                .build();
+                .originalText(original).
+                translatedText(result).
+                build();
     }
 }

--- a/src/main/java/com/tangtang/polingo/translate/service/Translation.java
+++ b/src/main/java/com/tangtang/polingo/translate/service/Translation.java
@@ -1,0 +1,5 @@
+package com.tangtang.polingo.translate.service;
+
+public interface Translation {
+    String translate(String text, String type);
+}

--- a/src/test/java/com/tangtang/polingo/integration/MyPageIntegrationTest.java
+++ b/src/test/java/com/tangtang/polingo/integration/MyPageIntegrationTest.java
@@ -1,11 +1,16 @@
 package com.tangtang.polingo.integration;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tangtang.polingo.global.constant.Language;
 import com.tangtang.polingo.security.service.JwtService;
 import com.tangtang.polingo.user.constant.LoginType;
-import com.tangtang.polingo.user.constant.UserRole;
 import com.tangtang.polingo.user.dto.UserResponse;
 import com.tangtang.polingo.user.entity.User;
 import com.tangtang.polingo.user.repository.UserRepository;
@@ -19,12 +24,6 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
-
-
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @Transactional
@@ -48,7 +47,7 @@ public class MyPageIntegrationTest {
 
     @Test
     @DisplayName("인증이 완료된 유저는 자신의 정보를 조회할 수 있다.")
-    public void testGivenJwtTokenWhenGetMyInfoThenReturnInfo() throws Exception{
+    public void testGivenJwtTokenWhenGetMyInfoThenReturnInfo() throws Exception {
         //given
         String jwtToken = createToken();
 
@@ -68,7 +67,7 @@ public class MyPageIntegrationTest {
 
     @Test
     @DisplayName("인증이 완료된 사용자는 자신의 기본 언어를 변경해 DB에 반영할 수 있다.")
-    public void testGivenAccessTokenWhenChangeDefaultLanguageThenSuccess() throws Exception{
+    public void testGivenAccessTokenWhenChangeDefaultLanguageThenSuccess() throws Exception {
         //given
         String jwtToken = createToken();
 
@@ -87,7 +86,7 @@ public class MyPageIntegrationTest {
 
     @Test
     @DisplayName("인증이 완료된 유저는 자신의 닉네임을 변경해 DB에 반영할 수 있다.")
-    public void testGivenAccessTokenWhenChangeNickNameThenSuccess() throws Exception{
+    public void testGivenAccessTokenWhenChangeNickNameThenSuccess() throws Exception {
         //given
         String jwtToken = createToken();
         //when
@@ -103,7 +102,6 @@ public class MyPageIntegrationTest {
         assertThat(user.getNickname()).isEqualTo("변경된닉네임");
 
     }
-
 
 
     private String createToken() {

--- a/src/test/java/com/tangtang/polingo/integration/UserOAuth2IntegrationTest.java
+++ b/src/test/java/com/tangtang/polingo/integration/UserOAuth2IntegrationTest.java
@@ -1,8 +1,8 @@
 package com.tangtang.polingo.integration;
 
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -12,13 +12,12 @@ import com.tangtang.polingo.global.constant.Language;
 import com.tangtang.polingo.testutils.MockServerSetUpUtils;
 import com.tangtang.polingo.testutils.TestGoogleProperties;
 import com.tangtang.polingo.testutils.TestKakaoProperties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.tangtang.polingo.user.constant.LoginType;
 import com.tangtang.polingo.user.constant.UserRole;
 import com.tangtang.polingo.user.entity.User;
 import com.tangtang.polingo.user.repository.UserRepository;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,20 +103,16 @@ public class UserOAuth2IntegrationTest {
         User actualUser = userRepository.findByLoginTypeAndProviderId(LoginType.GOOGLE, "1234567890")
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-
         assertAll("사용자의 정보가 모두 저장되고, 디폴트 단어장이 각 언어마다 한 개씩 저장되어야 한다.",
-                ()->assertThat(actualUser)
+                () -> assertThat(actualUser)
                         .extracting("nickname", "language", "role", "loginType", "providerId")
                         .contains("gildong hong", Language.ENGLISH, UserRole.COMMON, LoginType.GOOGLE, "1234567890"),
-                ()->assertThat(actualUser.getWordSets()).extracting("name", "language", "isDefault")
+                () -> assertThat(actualUser.getWordSets()).extracting("name", "language", "isDefault")
                         .contains(
                                 tuple("내 영어 단어장", Language.ENGLISH, true),
                                 tuple("내 일본어 단어장", Language.JAPAN, true)
                         )
         );
-
-
-
 
         mockServerSetUpUtils.close();
     }
@@ -167,17 +162,14 @@ public class UserOAuth2IntegrationTest {
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         assertAll("사용자의 정보가 모두 저장되고, 디폴트 단어장이 각 언어마다 한 개씩 저장되어야 한다.",
-                ()->assertThat(actualUser)
+                () -> assertThat(actualUser)
                         .extracting("nickname", "language", "role", "loginType", "providerId")
                         .contains("홍길동", Language.ENGLISH, UserRole.COMMON, LoginType.KAKAO, "123456789"),
-                ()->assertThat(actualUser.getWordSets()).extracting("name", "language", "isDefault")
+                () -> assertThat(actualUser.getWordSets()).extracting("name", "language", "isDefault")
                         .contains(
                                 tuple("내 영어 단어장", Language.ENGLISH, true),
                                 tuple("내 일본어 단어장", Language.JAPAN, true)
                         ));
-
-
-
 
         mockServerSetUpUtils.close();
 

--- a/src/test/java/com/tangtang/polingo/transtlate/TranslationTests.java
+++ b/src/test/java/com/tangtang/polingo/transtlate/TranslationTests.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
 @ContextConfiguration(classes = TranslatorConfig.class)
-public class TranslatorTests {
+public class TranslationTests {
     @Autowired
     private TranslatorConfig translatorConfig;
     private Translator translator;

--- a/src/test/resources/sql/init_user.sql
+++ b/src/test/resources/sql/init_user.sql
@@ -1,2 +1,2 @@
-INSERT INTO users (id, nickname, language, role, login_type, provider_id) VALUES
-    (1, '홍길동', 'ENGLISH', 'COMMON', 'GOOGLE', '123456789');
+INSERT INTO users (id, nickname, language, role, login_type, provider_id)
+VALUES (1, '홍길동', 'ENGLISH', 'COMMON', 'GOOGLE', '123456789');


### PR DESCRIPTION
- TranslateService에서 DeepL과 직접적인 의존관계 제거
- DeepLTranslationImpl로 구현을 분리함으로써 번역 기능을 모듈화 -> 이를 통해 이미지 번역, 음성 번역에서 위 구현체를 재활용 예정